### PR TITLE
Switch to new benchmark suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,6 @@ jobs:
           auto-push: true
           gh-pages-branch: gh-pages-benchmarks-2
           comment-always: false
-          fail-on-alert: true
+          fail-on-alert: false
           alert-threshold: "150%"
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
           tool: customSmallerIsBetter
           output-file-path: ${{ runner.temp }}/benchmark-data.json
           auto-push: true
-          gh-pages-branch: gh-pages-benchmarks
+          gh-pages-branch: gh-pages-benchmarks-2
           comment-always: false
           fail-on-alert: true
           alert-threshold: "150%"

--- a/packages/TraceDebuggerBenchmarks.package/TDBBenchmark.class/instance/setUp.st
+++ b/packages/TraceDebuggerBenchmarks.package/TDBBenchmark.class/instance/setUp.st
@@ -2,3 +2,6 @@ running
 setUp
 
 	wrappers := OrderedCollection new.
+	
+	Simulator warmUp.
+	Smalltalk garbageCollect.

--- a/packages/TraceDebuggerBenchmarks.package/TDBBenchmark.class/methodProperties.json
+++ b/packages/TraceDebuggerBenchmarks.package/TDBBenchmark.class/methodProperties.json
@@ -34,7 +34,7 @@
 		"runWithoutTimeout" : "ct 1/8/2022 14:26",
 		"selector" : "ct 1/8/2022 14:09",
 		"selector:" : "ct 1/8/2022 14:09",
-		"setUp" : "ct 1/8/2022 14:33",
+		"setUp" : "ct 1/11/2022 21:16",
 		"shortPrintOn:" : "ct 1/8/2022 15:43",
 		"shortPrintString" : "ct 1/8/2022 15:43",
 		"tearDown" : "ct 1/8/2022 16:25",

--- a/packages/TraceDebuggerBenchmarks.package/TDBBenchmarkRunner.class/class/runForVersionsHashes..st
+++ b/packages/TraceDebuggerBenchmarks.package/TDBBenchmarkRunner.class/class/runForVersionsHashes..st
@@ -2,15 +2,17 @@ bulk running
 runForVersionsHashes: versionHashes
 	"Run all benchmarks for each of the specified version hashes (aka commit SHAs) and export the results for each version in a separate file. You may check in these results into the github-action-benchmark- database for GitHub pages by passing these files to the run_local.ts script, see: https://github.com/benchmark-action/github-action-benchmark/pull/99"
 
-	| versions workingCopy |
+	| versions workingCopy benchmarksSnapshot |
 	workingCopy := (Smalltalk classNamed: #SquotWorkingCopy) registered
 		detect: [:ea | ea name = #TraceDebugger].
 	versions := versionHashes collect: [:hash | workingCopy repository versionAt: hash].
+	benchmarksSnapshot := TDBBenchmarkRunner packageInfo mcPackage snapshot.
 	
 	Transcript openIfNone.
 	versions
 		do: [:version | | runner |
 			workingCopy loadVersion: version interactive: false.
+			benchmarksSnapshot install.
 			runner := self newDefault
 				resultsFilePath: ('benchmark-results-{1}.json' format: {version hexHash});
 				yourself.

--- a/packages/TraceDebuggerBenchmarks.package/TDBBenchmarkRunner.class/instance/resultAsJson..st
+++ b/packages/TraceDebuggerBenchmarks.package/TDBBenchmarkRunner.class/instance/resultAsJson..st
@@ -7,10 +7,11 @@ resultAsJson: benches
 		name: benches anyOne shortPrintString;
 		unit: 'Milliseconds';
 		value: timesToRun average asFloat;
-		range: ('stdev: {1}' format: {timesToRun tdbSampleVariance asFloat});
+		range: ('stdev: {1}' format: {timesToRun tdbStdev asFloat});
 		extra: (JsonObject new
 			totalTime: (benches collect: [:ea | ea totalTime asMilliSeconds]) average asFloat;
 			preparationTime: (benches collect: [:ea | ea preparationTime asMilliSeconds]) average asFloat;
 			postparationTime: (benches collect: [:ea | ea postparationTime asMilliSeconds]) average asFloat;
+			singleTimesToRun: (timesToRun collect: [:ea | ea asFloat]);
 			asJsonString);
 		yourself

--- a/packages/TraceDebuggerBenchmarks.package/TDBBenchmarkRunner.class/methodProperties.json
+++ b/packages/TraceDebuggerBenchmarks.package/TDBBenchmarkRunner.class/methodProperties.json
@@ -10,7 +10,7 @@
 		"parseHistoricBench:" : "ct 1/9/2022 02:11",
 		"parseHistoricRawData:" : "ct 1/9/2022 01:52",
 		"run" : "ct 1/8/2022 15:39",
-		"runForVersionsHashes:" : "ct 1/9/2022 17:57",
+		"runForVersionsHashes:" : "ct 1/11/2022 14:49",
 		"testSelector" : "ct 1/8/2022 15:38" },
 	"instance" : {
 		"benchmarkClass" : "ct 1/8/2022 15:24",
@@ -18,7 +18,7 @@
 		"configAt:ifAbsent:" : "ct 1/8/2022 15:42",
 		"exportResults" : "ct 1/8/2022 15:37",
 		"getEnv:" : "ct 1/8/2022 15:31",
-		"resultAsJson:" : "ct 1/9/2022 02:07",
+		"resultAsJson:" : "ct 1/11/2022 13:48",
 		"resultsAsJson" : "ct 1/9/2022 03:33",
 		"resultsFilePath" : "ct 1/9/2022 02:57",
 		"resultsFilePath:" : "ct 1/9/2022 02:57",

--- a/packages/TraceDebuggerBenchmarks.package/TDBRetracingSimulatorBenchmark.class/instance/benchProxyImageForm.st
+++ b/packages/TraceDebuggerBenchmarks.package/TDBRetracingSimulatorBenchmark.class/instance/benchProxyImageForm.st
@@ -9,6 +9,6 @@ benchProxyImageForm
 		morph privateBounds: bounds.
 		morph privateFullBounds: fullBounds].
 	
-	100 timesRepeat: [
-		morph step.
+	500 timesRepeat:
+		[morph step.
 		morph imageForm].

--- a/packages/TraceDebuggerBenchmarks.package/TDBRetracingSimulatorBenchmark.class/methodProperties.json
+++ b/packages/TraceDebuggerBenchmarks.package/TDBRetracingSimulatorBenchmark.class/methodProperties.json
@@ -2,5 +2,5 @@
 	"class" : {
 		 },
 	"instance" : {
-		"benchProxyImageForm" : "ct 1/8/2022 16:26",
+		"benchProxyImageForm" : "ct 1/11/2022 21:54",
 		"simulatorClass" : "ct 1/8/2022 16:34" } }

--- a/packages/TraceDebuggerBenchmarks.package/TDBSimulatorBenchmark.class/instance/benchRegex.st
+++ b/packages/TraceDebuggerBenchmarks.package/TDBSimulatorBenchmark.class/instance/benchRegex.st
@@ -11,4 +11,4 @@ benchRegex
 					ifTrue: [$ ]
 					ifFalse: [(random nextInt: 255) asCharacter])]]].
 	
-	[simulator evaluate: ['(?<=\w*\s)\w+' asRegex matchesIn: string]] timeToRun.
+	simulator evaluate: ['(\w*\s)\w+' asRegex matchesIn: string].

--- a/packages/TraceDebuggerBenchmarks.package/TDBSimulatorBenchmark.class/instance/factorialFactor.st
+++ b/packages/TraceDebuggerBenchmarks.package/TDBSimulatorBenchmark.class/instance/factorialFactor.st
@@ -1,4 +1,4 @@
 accessing
 factorialFactor
 
-	^ 50000
+	^ 100000

--- a/packages/TraceDebuggerBenchmarks.package/TDBSimulatorBenchmark.class/methodProperties.json
+++ b/packages/TraceDebuggerBenchmarks.package/TDBSimulatorBenchmark.class/methodProperties.json
@@ -3,8 +3,8 @@
 		"isAbstract" : "ct 1/8/2022 16:50" },
 	"instance" : {
 		"benchFactorial" : "ct 1/8/2022 18:47",
-		"benchRegex" : "ct 1/8/2022 18:43",
-		"factorialFactor" : "ct 1/8/2022 18:52",
+		"benchRegex" : "ct 1/11/2022 20:08",
+		"factorialFactor" : "ct 1/11/2022 21:40",
 		"memoryClass" : "ct 1/8/2022 16:49",
 		"regexStringSize" : "ct 1/8/2022 17:06",
 		"setUp" : "ct 1/8/2022 16:49",

--- a/packages/TraceDebuggerBenchmarks.package/TraceDebuggerBenchmark.class/instance/benchExpandAll.st
+++ b/packages/TraceDebuggerBenchmarks.package/TraceDebuggerBenchmark.class/instance/benchExpandAll.st
@@ -2,8 +2,8 @@ benchmarks
 benchExpandAll
 
 	| item previousItem tree |
-	self prepare: [
-		self openDebuggerForBlock: ['\w+' asRegex].
+	self prepare:
+		[self openDebuggerForBlock: ['\w+[a-z]*' asRegex].
 		tree := window findA: PluggableTreeMorph.
 		item := previousItem := nil.
 		debugger stepOver].
@@ -14,10 +14,10 @@ benchExpandAll
 	self displayWindow]
 		doWhileTrue: [
 			tree selectedMorph = previousItem
-				ifTrue: [
-					item canExpand
+				ifTrue:
+					[item canExpand
 						and: [item isExpanded not]]
-				ifFalse: [
-					previousItem := item.
+				ifFalse:
+					[previousItem := item.
 					item := tree selectedMorph.
-					true]]
+					true]].

--- a/packages/TraceDebuggerBenchmarks.package/TraceDebuggerBenchmark.class/instance/benchStepInto.st
+++ b/packages/TraceDebuggerBenchmarks.package/TraceDebuggerBenchmark.class/instance/benchStepInto.st
@@ -1,0 +1,11 @@
+benchmarks
+benchStepInto
+
+	self prepare:
+		[self openDebuggerForBlock: [6 / 7]].
+	
+	[debugger canStepForward] whileTrue:
+		[debugger stepInto.
+		self displayWindow].
+	
+	self assert: debugger process isTerminated.

--- a/packages/TraceDebuggerBenchmarks.package/TraceDebuggerBenchmark.class/instance/benchStepOver.st
+++ b/packages/TraceDebuggerBenchmarks.package/TraceDebuggerBenchmark.class/instance/benchStepOver.st
@@ -1,8 +1,8 @@
 benchmarks
 benchStepOver
 
-	self prepare: [
-		self openDebuggerForBlock: [WatchMorph new imageForm]].
+	self prepare:
+		[self openDebuggerForBlock: [WatchMorph new imageForm]].
 	
 	debugger stepOver.
 	self displayWindow.

--- a/packages/TraceDebuggerBenchmarks.package/TraceDebuggerBenchmark.class/instance/installSightProtection.st
+++ b/packages/TraceDebuggerBenchmarks.package/TraceDebuggerBenchmark.class/instance/installSightProtection.st
@@ -1,0 +1,7 @@
+support
+installSightProtection
+
+	self wrap: [:block | | morph |
+		morph := Morph newBounds: Project current world bounds.
+		morph  openInWorld.
+		block ensure: [morph abandon]].

--- a/packages/TraceDebuggerBenchmarks.package/TraceDebuggerBenchmark.class/instance/setUp.st
+++ b/packages/TraceDebuggerBenchmarks.package/TraceDebuggerBenchmark.class/instance/setUp.st
@@ -1,0 +1,7 @@
+running
+setUp
+
+	super setUp.
+	
+	self installSightProtection.
+	self displayWindow.

--- a/packages/TraceDebuggerBenchmarks.package/TraceDebuggerBenchmark.class/methodProperties.json
+++ b/packages/TraceDebuggerBenchmarks.package/TraceDebuggerBenchmark.class/methodProperties.json
@@ -2,10 +2,13 @@
 	"class" : {
 		 },
 	"instance" : {
-		"benchExpandAll" : "ct 1/8/2022 19:11",
-		"benchStepOver" : "ct 1/8/2022 19:11",
+		"benchExpandAll" : "ct 1/11/2022 21:53",
+		"benchStepInto" : "ct 1/11/2022 21:26",
+		"benchStepOver" : "ct 1/11/2022 21:26",
 		"debuggerClass" : "ct 1/8/2022 14:29",
 		"displayWindow" : "ct 1/8/2022 14:23",
 		"dontOpenToolsAttachedToMouseCursorDuring:" : "ct 1/8/2022 14:35",
+		"installSightProtection" : "ct 1/11/2022 13:46",
 		"openDebuggerForBlock:" : "ct 1/8/2022 19:10",
+		"setUp" : "ct 1/11/2022 13:45",
 		"tearDown" : "ct 1/8/2022 14:29" } }


### PR DESCRIPTION
Second attempt on a meaningful benchmark suite. Revises benchmark definition, adds a warm-up phase, and provides further benchmark workloads. The new benchmarks are stored on branch https://github.com/LinqLover/squeak-tracedebugger/tree/gh-pages-benchmarks-2. All results in the ancestry of ba1a133 have been computed locally.